### PR TITLE
feat: jwt 회원 관리 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### 환경 변수 및 보안 파일 ###
+/src/main/resources/application.yml

--- a/src/main/java/com/teachtouch/backend/auth/dto/TokenRefreshRequestDto.java
+++ b/src/main/java/com/teachtouch/backend/auth/dto/TokenRefreshRequestDto.java
@@ -1,0 +1,8 @@
+package com.teachtouch.backend.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TokenRefreshRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/com/teachtouch/backend/auth/dto/TokenRefreshResponseDto.java
+++ b/src/main/java/com/teachtouch/backend/auth/dto/TokenRefreshResponseDto.java
@@ -1,0 +1,10 @@
+package com.teachtouch.backend.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenRefreshResponseDto {
+    private String accessToken;
+}

--- a/src/main/java/com/teachtouch/backend/auth/entity/RefreshToken.java
+++ b/src/main/java/com/teachtouch/backend/auth/entity/RefreshToken.java
@@ -1,0 +1,21 @@
+package com.teachtouch.backend.auth.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+
+    @Id
+    private String loginId;
+
+    private String token;
+}

--- a/src/main/java/com/teachtouch/backend/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/teachtouch/backend/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.teachtouch.backend.auth.repository;
+
+import com.teachtouch.backend.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken,String> {
+}

--- a/src/main/java/com/teachtouch/backend/global/config/JpaConfig.java
+++ b/src/main/java/com/teachtouch/backend/global/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.teachtouch.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/teachtouch/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/teachtouch/backend/global/config/SecurityConfig.java
@@ -1,0 +1,61 @@
+package com.teachtouch.backend.global.config;
+
+import com.teachtouch.backend.global.jwt.JwtAuthenticationFilter;
+import com.teachtouch.backend.global.jwt.JwtProvider;
+import com.teachtouch.backend.global.security.CustomUserDetailsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtProvider jwtProvider;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth->auth
+                        .requestMatchers(
+                                "/api/v1.0/user/signup",
+                                "api/v1.0/user/login",
+                                "api/v1.0/user/check-id",
+                                "api/v1.0/user/reissue",
+                                "/oauth2/**"
+
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtProvider,customUserDetailsService),
+                        UsernamePasswordAuthenticationFilter.class
+                );
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration config
+    ) throws Exception{
+        return config.getAuthenticationManager();
+    }
+
+}

--- a/src/main/java/com/teachtouch/backend/global/entity/BaseEntity.java
+++ b/src/main/java/com/teachtouch/backend/global/entity/BaseEntity.java
@@ -1,0 +1,33 @@
+package com.teachtouch.backend.global.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter(value = AccessLevel.PROTECTED)
+@MappedSuperclass
+@SuperBuilder
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Builder.Default
+    private Boolean deleted = false;
+}

--- a/src/main/java/com/teachtouch/backend/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/teachtouch/backend/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.teachtouch.backend.global.jwt;
+
+
+import com.teachtouch.backend.global.security.CustomUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtProvider.validateToken(token)) {
+            String loginId = jwtProvider.getLoginIdFromToken(token);
+            UserDetails userDetails = customUserDetailsService.loadUserByUsername(loginId);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+            authentication.setDetails(
+                    new WebAuthenticationDetailsSource().buildDetails(request)
+            );
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/teachtouch/backend/global/jwt/JwtProvider.java
+++ b/src/main/java/com/teachtouch/backend/global/jwt/JwtProvider.java
@@ -1,0 +1,80 @@
+package com.teachtouch.backend.global.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secret; // Base64 권장(32바이트 이상)
+
+    @Value("${jwt.expiration}")
+    private long expirationMs; // access 토큰 만료(ms)
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        if (secret == null || secret.isBlank()) {
+            throw new IllegalStateException("jwt.secret이 비어 있습니다. application.yml을 확인하세요.");
+        }
+        // Base64 시크릿 우선 사용, 아니면 평문 사용
+        try {
+            byte[] keyBytes = Decoders.BASE64.decode(secret);
+            this.key = Keys.hmacShaKeyFor(keyBytes);
+        } catch (IllegalArgumentException e) {
+            // Base64가 아니면 평문. HS256은 32바이트 이상 권장
+            this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    public String generateAccessToken(String loginId) {
+        long now = System.currentTimeMillis();
+        return Jwts.builder()
+                .setSubject(loginId)
+                .setIssuedAt(new Date(now))
+                .setExpiration(new Date(now + expirationMs))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(String loginId) {
+        long now = System.currentTimeMillis();
+        long refreshMs = 1000L * 60 * 60 * 24 * 14; // 필요하면 yml로 분리 가능
+        return Jwts.builder()
+                .setSubject(loginId)
+                .setIssuedAt(new Date(now))
+                .setExpiration(new Date(now + refreshMs))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getLoginIdFromToken(String token) {
+        return parseClaims(token).getBody().getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private Jws<Claims> parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+}

--- a/src/main/java/com/teachtouch/backend/global/security/CustomUserDetails.java
+++ b/src/main/java/com/teachtouch/backend/global/security/CustomUserDetails.java
@@ -1,0 +1,42 @@
+package com.teachtouch.backend.global.security;
+
+
+import com.teachtouch.backend.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 권한이 필요할 경우 로직 추가
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getLoginId();
+    }
+
+
+
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/teachtouch/backend/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/teachtouch/backend/global/security/CustomUserDetailsService.java
@@ -1,0 +1,25 @@
+package com.teachtouch.backend.global.security;
+
+import com.teachtouch.backend.user.entity.User;
+import com.teachtouch.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(()->new UsernameNotFoundException("해당 이메일을 찾을 수 없습니다."));
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/com/teachtouch/backend/user/controller/UserController.java
+++ b/src/main/java/com/teachtouch/backend/user/controller/UserController.java
@@ -1,0 +1,60 @@
+package com.teachtouch.backend.user.controller;
+
+
+import com.teachtouch.backend.auth.dto.TokenRefreshRequestDto;
+import com.teachtouch.backend.auth.dto.TokenRefreshResponseDto;
+import com.teachtouch.backend.user.dto.UserLoginRequestDto;
+import com.teachtouch.backend.user.dto.UserLoginResponseDto;
+import com.teachtouch.backend.user.dto.UserSignupRequestDto;
+import com.teachtouch.backend.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1.0/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(@RequestBody UserSignupRequestDto dto) {
+        userService.signup(dto);
+        return ResponseEntity.ok("회원가입 성공!");
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<UserLoginResponseDto> login(@RequestBody UserLoginRequestDto dto) {
+        return ResponseEntity.ok(userService.login(dto));
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenRefreshResponseDto> reissue(@RequestBody TokenRefreshRequestDto dto) {
+        return ResponseEntity.ok(userService.reissueAccessToken(dto));
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<String> delete(@RequestHeader("Authorization") String token) {
+        String loginId = userService.getLoginIdFromToken(token);
+        userService.delete(loginId);
+        return ResponseEntity.ok("탈퇴 완료");
+    }
+    @GetMapping("/check-id")
+    public ResponseEntity<Boolean> checkLoginIdDuplicate(@RequestParam String loginId) {
+        boolean isDuplicate = userService.checkLoginIdDuplicate(loginId);
+        return ResponseEntity.ok(isDuplicate);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(@RequestHeader("Authorization") String token) {
+        String loginId = userService.getLoginIdFromToken(token);
+        userService.logout(loginId);
+        return ResponseEntity.ok("로그아웃 완료");
+    }
+
+
+
+
+}

--- a/src/main/java/com/teachtouch/backend/user/dto/UserLoginRequestDto.java
+++ b/src/main/java/com/teachtouch/backend/user/dto/UserLoginRequestDto.java
@@ -1,0 +1,9 @@
+package com.teachtouch.backend.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserLoginRequestDto {
+    private String loginId;
+    private String password;
+}

--- a/src/main/java/com/teachtouch/backend/user/dto/UserLoginResponseDto.java
+++ b/src/main/java/com/teachtouch/backend/user/dto/UserLoginResponseDto.java
@@ -1,0 +1,11 @@
+package com.teachtouch.backend.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserLoginResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/teachtouch/backend/user/dto/UserResponseDto.java
+++ b/src/main/java/com/teachtouch/backend/user/dto/UserResponseDto.java
@@ -1,0 +1,4 @@
+package com.teachtouch.backend.user.dto;
+
+public class UserResponseDto {
+}

--- a/src/main/java/com/teachtouch/backend/user/dto/UserSignupRequestDto.java
+++ b/src/main/java/com/teachtouch/backend/user/dto/UserSignupRequestDto.java
@@ -1,0 +1,14 @@
+package com.teachtouch.backend.user.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class UserSignupRequestDto {
+    private String loginId;
+    private String password;
+    private String username;
+    private String gender;
+    private LocalDate birthdate;
+}

--- a/src/main/java/com/teachtouch/backend/user/entity/User.java
+++ b/src/main/java/com/teachtouch/backend/user/entity/User.java
@@ -1,0 +1,48 @@
+package com.teachtouch.backend.user.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.teachtouch.backend.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Entity
+@Table(name = "user")
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(
+            nullable = false,
+            unique = true,
+            columnDefinition = "varchar(255) collate utf8mb4_bin"
+    )
+    private String loginId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String username;
+
+
+    private String gender;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate birthDate;
+
+    }

--- a/src/main/java/com/teachtouch/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/teachtouch/backend/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.teachtouch.backend.user.repository;
+
+import com.teachtouch.backend.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User,Long> {
+    Optional<User> findByLoginId(String loginId);
+    boolean existsByLoginId(String loginId);
+
+}

--- a/src/main/java/com/teachtouch/backend/user/service/UserService.java
+++ b/src/main/java/com/teachtouch/backend/user/service/UserService.java
@@ -1,0 +1,23 @@
+package com.teachtouch.backend.user.service;
+
+import com.teachtouch.backend.auth.dto.TokenRefreshRequestDto;
+import com.teachtouch.backend.auth.dto.TokenRefreshResponseDto;
+import com.teachtouch.backend.user.dto.UserLoginRequestDto;
+import com.teachtouch.backend.user.dto.UserLoginResponseDto;
+import com.teachtouch.backend.user.dto.UserSignupRequestDto;
+
+public interface UserService {
+
+    void signup(UserSignupRequestDto requestDto);
+    UserLoginResponseDto login(UserLoginRequestDto requestDto);
+
+    void logout(String loginId);
+
+    void delete(String loginId);
+
+    String getLoginIdFromToken(String token);
+
+    TokenRefreshResponseDto reissueAccessToken(TokenRefreshRequestDto requestDto);
+
+    boolean checkLoginIdDuplicate(String loginId);
+}

--- a/src/main/java/com/teachtouch/backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/teachtouch/backend/user/service/UserServiceImpl.java
@@ -1,0 +1,108 @@
+package com.teachtouch.backend.user.service;
+
+import com.teachtouch.backend.auth.dto.TokenRefreshRequestDto;
+import com.teachtouch.backend.auth.dto.TokenRefreshResponseDto;
+import com.teachtouch.backend.auth.entity.RefreshToken;
+import com.teachtouch.backend.auth.repository.RefreshTokenRepository;
+import com.teachtouch.backend.global.jwt.JwtProvider;
+import com.teachtouch.backend.user.dto.UserLoginRequestDto;
+import com.teachtouch.backend.user.dto.UserLoginResponseDto;
+import com.teachtouch.backend.user.dto.UserSignupRequestDto;
+import com.teachtouch.backend.user.entity.User;
+import com.teachtouch.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public boolean checkLoginIdDuplicate(String loginId) {
+        return userRepository.existsByLoginId(loginId);
+    }
+
+    @Override
+    public void signup(UserSignupRequestDto requestDto) {
+        if (userRepository.findByLoginId(requestDto.getLoginId()).isPresent()) {
+            throw new IllegalArgumentException("이미 사용 중인 아이디입니다.");
+        }
+        if (requestDto.getUsername() == null || requestDto.getUsername().isBlank()) {
+            throw new IllegalArgumentException("이름은 필수입니다.");
+        }
+
+        User user = User.builder()
+                .loginId(requestDto.getLoginId())
+                .password(passwordEncoder.encode(requestDto.getPassword()))
+                .username(requestDto.getUsername())
+                .gender(requestDto.getGender())
+                .birthDate(requestDto.getBirthdate())
+                .build();
+
+        userRepository.save(user);
+    }
+
+    @Override
+    public UserLoginResponseDto login(UserLoginRequestDto requestDto) {
+        User user = userRepository.findByLoginId(requestDto.getLoginId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다."));
+        if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        String accessToken = jwtProvider.generateAccessToken(user.getLoginId());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getLoginId());
+
+        refreshTokenRepository.save(
+                RefreshToken.builder()
+                        .loginId(user.getLoginId())
+                        .token(refreshToken)
+                        .build()
+        );
+
+        return new UserLoginResponseDto(accessToken, refreshToken);
+    }
+
+    @Override
+    public void logout(String loginId) {
+        refreshTokenRepository.deleteById(loginId);
+    }
+
+
+    @Override
+    public void delete(String loginId) {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+        userRepository.delete(user);
+    }
+
+    public String getLoginIdFromToken(String token) {
+        return jwtProvider.getLoginIdFromToken(token.replace("Bearer ", ""));
+    }
+
+    @Override
+    public TokenRefreshResponseDto reissueAccessToken(TokenRefreshRequestDto requestDto) {
+        String refreshToken = requestDto.getRefreshToken();
+
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다.");
+        }
+
+        String loginId = jwtProvider.getLoginIdFromToken(refreshToken);
+
+        RefreshToken saved = refreshTokenRepository.findById(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("저장된 리프레시 토큰을 찾을 수 없습니다."));
+
+        if (!saved.getToken().equals(refreshToken)) {
+            throw new IllegalArgumentException("리프레시 토큰이 일치하지 않습니다.");
+        }
+
+        String newAccessToken = jwtProvider.generateAccessToken(loginId);
+        return new TokenRefreshResponseDto(newAccessToken);
+    }
+}


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #1` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

- JWT 로그인
- 회원가입
- access token 재발급
- 로그아웃
- 회원탈퇴
- 아이디 중복 확인
- 
## #️⃣ 테스트 결과

- 테스트 통과 하였으며 API 명세서에 테스트 결과 캡쳐 화면 첨부하였습니다.

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요