### PR TITLE
feat : 가이드 생성 & 상품 등록 추가

### DIFF
--- a/src/main/java/com/teachtouch/backend/example/controller/ExampleController.java
+++ b/src/main/java/com/teachtouch/backend/example/controller/ExampleController.java
@@ -1,0 +1,26 @@
+package com.teachtouch.backend.example.controller;
+
+import com.teachtouch.backend.example.dto.ExampleRequestDTO;
+import com.teachtouch.backend.example.dto.ExampleResponseDTO;
+import com.teachtouch.backend.example.entity.Example;
+import com.teachtouch.backend.example.service.ExampleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1.0/examples")
+@RequiredArgsConstructor
+public class ExampleController {
+    private final ExampleService exampleService;
+
+    @PostMapping
+    public ResponseEntity<ExampleResponseDTO> createExample(@RequestBody ExampleRequestDTO dto){
+        Example saved = exampleService.createExample(dto);
+        return ResponseEntity.ok(ExampleResponseDTO.fromEntity(saved));
+    }
+
+}

--- a/src/main/java/com/teachtouch/backend/example/dto/ExampleRequestDTO.java
+++ b/src/main/java/com/teachtouch/backend/example/dto/ExampleRequestDTO.java
@@ -1,0 +1,6 @@
+package com.teachtouch.backend.example.dto;
+
+public record ExampleRequestDTO (
+        Long productId,
+        int quantity
+){}

--- a/src/main/java/com/teachtouch/backend/example/dto/ExampleResponseDTO.java
+++ b/src/main/java/com/teachtouch/backend/example/dto/ExampleResponseDTO.java
@@ -1,0 +1,17 @@
+package com.teachtouch.backend.example.dto;
+
+import com.teachtouch.backend.example.entity.Example;
+
+public record ExampleResponseDTO(
+        Long id,
+        Long productId,
+        int quantity
+) {
+    public static ExampleResponseDTO fromEntity(Example example){
+        return new ExampleResponseDTO(
+                example.getId(),
+                example.getProductId(),
+                example.getQuantity()
+        );
+    }
+}

--- a/src/main/java/com/teachtouch/backend/example/entity/Example.java
+++ b/src/main/java/com/teachtouch/backend/example/entity/Example.java
@@ -1,0 +1,23 @@
+package com.teachtouch.backend.example.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "examples")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Example {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long productId;
+    private int quantity;
+
+
+}

--- a/src/main/java/com/teachtouch/backend/example/repository/ExampleRepository.java
+++ b/src/main/java/com/teachtouch/backend/example/repository/ExampleRepository.java
@@ -1,0 +1,9 @@
+package com.teachtouch.backend.example.repository;
+
+import com.teachtouch.backend.example.entity.Example;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ExampleRepository extends JpaRepository<Example,Long> {
+}

--- a/src/main/java/com/teachtouch/backend/example/service/ExampleService.java
+++ b/src/main/java/com/teachtouch/backend/example/service/ExampleService.java
@@ -1,0 +1,9 @@
+package com.teachtouch.backend.example.service;
+
+import com.teachtouch.backend.example.dto.ExampleRequestDTO;
+import com.teachtouch.backend.example.entity.Example;
+import com.teachtouch.backend.product.dto.ProductRequestDTO;
+
+public interface ExampleService {
+    Example createExample(ExampleRequestDTO dto);
+}

--- a/src/main/java/com/teachtouch/backend/example/service/ExampleServiceImpl.java
+++ b/src/main/java/com/teachtouch/backend/example/service/ExampleServiceImpl.java
@@ -1,0 +1,23 @@
+package com.teachtouch.backend.example.service;
+
+import com.teachtouch.backend.example.dto.ExampleRequestDTO;
+import com.teachtouch.backend.example.entity.Example;
+import com.teachtouch.backend.example.repository.ExampleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ExampleServiceImpl implements ExampleService{
+    private final ExampleRepository exampleRepository;
+    @Override
+    public Example createExample(ExampleRequestDTO dto) {
+
+        Example ex = new Example();
+        ex.setProductId(dto.productId());
+        ex.setQuantity(dto.quantity());
+        return exampleRepository.save(ex);
+    }
+}

--- a/src/main/java/com/teachtouch/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/teachtouch/backend/global/config/SecurityConfig.java
@@ -34,6 +34,10 @@ public class SecurityConfig {
                                 "api/v1.0/user/login",
                                 "api/v1.0/user/check-id",
                                 "api/v1.0/user/reissue",
+                                "/api/v1.0/products",
+                                "/api/v1.0/products/batch",
+                                "/api/v1.0/examples",
+                                "/api/v1.0/guides",
                                 "/oauth2/**"
 
                         ).permitAll()

--- a/src/main/java/com/teachtouch/backend/guide/controller/GuideController.java
+++ b/src/main/java/com/teachtouch/backend/guide/controller/GuideController.java
@@ -1,0 +1,26 @@
+package com.teachtouch.backend.guide.controller;
+
+import com.teachtouch.backend.guide.dto.GuideRequestDTO;
+import com.teachtouch.backend.guide.dto.GuideResponseDTO;
+import com.teachtouch.backend.guide.entity.Guide;
+import com.teachtouch.backend.guide.service.GuideService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1.0/guides")
+@RequiredArgsConstructor
+public class GuideController {
+
+    private final GuideService guideService;
+
+    @PostMapping
+    public ResponseEntity<GuideResponseDTO>upsertGuide(@RequestBody GuideRequestDTO dto){
+        Guide saved = guideService.upsertGuide(dto);
+        return ResponseEntity.ok(GuideResponseDTO.fromEntity(saved));
+    }
+}

--- a/src/main/java/com/teachtouch/backend/guide/converter/MetadataConverter.java
+++ b/src/main/java/com/teachtouch/backend/guide/converter/MetadataConverter.java
@@ -1,0 +1,36 @@
+package com.teachtouch.backend.guide.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Converter
+public class MetadataConverter implements AttributeConverter<Map<String, Object>, String> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, Object> attribute) {
+        if (attribute == null) return null;
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("metadata 직렬화 실패", e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        try {
+            return objectMapper.readValue(dbData, new TypeReference<>() {});
+        } catch (IOException e) {
+            throw new IllegalArgumentException("metadata 역직렬화 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/teachtouch/backend/guide/dto/GuideRequestDTO.java
+++ b/src/main/java/com/teachtouch/backend/guide/dto/GuideRequestDTO.java
@@ -1,0 +1,16 @@
+package com.teachtouch.backend.guide.dto;
+
+import com.teachtouch.backend.example.dto.ExampleRequestDTO;
+
+import java.util.List;
+
+public record GuideRequestDTO(
+        Long id,
+        String title,
+        String category,
+        String description,
+        List<Long>productIds,
+        List<ExampleRequestDTO>examples,
+        List<StepRequestDTO> steps
+) {
+}

--- a/src/main/java/com/teachtouch/backend/guide/dto/GuideResponseDTO.java
+++ b/src/main/java/com/teachtouch/backend/guide/dto/GuideResponseDTO.java
@@ -1,0 +1,19 @@
+package com.teachtouch.backend.guide.dto;
+
+import com.teachtouch.backend.guide.entity.Guide;
+
+public record GuideResponseDTO(
+        Long id,
+        String title,
+        String category,
+        String description
+) {
+    public static GuideResponseDTO fromEntity(Guide guide){
+        return new GuideResponseDTO(
+                guide.getId(),
+                guide.getTitle(),
+                guide.getCategory(),
+                guide.getDescription()
+        );
+    }
+}

--- a/src/main/java/com/teachtouch/backend/guide/dto/StepRequestDTO.java
+++ b/src/main/java/com/teachtouch/backend/guide/dto/StepRequestDTO.java
@@ -1,0 +1,17 @@
+package com.teachtouch.backend.guide.dto;
+
+import com.teachtouch.backend.example.dto.ExampleRequestDTO;
+
+import java.util.List;
+import java.util.Map;
+
+public record StepRequestDTO(
+        String stepCode,
+        String title,
+        String type,
+        String content,
+        List<Long> productIds,
+        List<ExampleRequestDTO> examples,
+        List<StepRequestDTO> subSteps ,
+        Map<String,Object> metadata
+) {}

--- a/src/main/java/com/teachtouch/backend/guide/entity/Guide.java
+++ b/src/main/java/com/teachtouch/backend/guide/entity/Guide.java
@@ -1,0 +1,44 @@
+package com.teachtouch.backend.guide.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "guides")
+@Getter
+@Setter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Guide {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private String category;
+    private String description;
+
+    @OneToMany(mappedBy = "guide")
+    private List<GuideProduct> products = new ArrayList<>();
+
+    @OneToMany(mappedBy = "guide")
+    private List<GuideExample> examples = new ArrayList<>();
+
+    @OneToMany(mappedBy = "guide", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Step> steps = new ArrayList<>();
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/com/teachtouch/backend/guide/entity/GuideExample.java
+++ b/src/main/java/com/teachtouch/backend/guide/entity/GuideExample.java
@@ -1,0 +1,28 @@
+package com.teachtouch.backend.guide.entity;
+
+import com.teachtouch.backend.product.entity.Product;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "guide_examples")
+@Getter
+@Setter
+@NoArgsConstructor
+public class GuideExample {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private int quantity;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guide_id")
+    private Guide guide;
+
+
+}

--- a/src/main/java/com/teachtouch/backend/guide/entity/GuideProduct.java
+++ b/src/main/java/com/teachtouch/backend/guide/entity/GuideProduct.java
@@ -1,0 +1,26 @@
+package com.teachtouch.backend.guide.entity;
+
+import com.teachtouch.backend.product.entity.Product;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "guide_products")
+@Getter
+@Setter
+@NoArgsConstructor
+public class GuideProduct {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private int quantity;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guide_id")
+    private Guide guide;
+}

--- a/src/main/java/com/teachtouch/backend/guide/entity/Step.java
+++ b/src/main/java/com/teachtouch/backend/guide/entity/Step.java
@@ -1,0 +1,43 @@
+package com.teachtouch.backend.guide.entity;
+
+import com.teachtouch.backend.guide.converter.MetadataConverter;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Entity
+@Table(name = "steps")
+@Getter @Setter @NoArgsConstructor
+public class Step {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String stepCode;     // "1", "1-1", "2-2" 계층형 구조
+    private String title;
+    private String type;
+
+    @Column(columnDefinition = "TEXT") // 설명이 길어질 것을 대비
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guide_id")
+    private Guide guide;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_step_id")
+    private Step parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Step> subSteps = new ArrayList<>();
+
+    @Column(columnDefinition = "json")
+    @Convert(converter = MetadataConverter.class)
+    private Map<String,Object> metadata;
+}
+

--- a/src/main/java/com/teachtouch/backend/guide/repository/GuideRepository.java
+++ b/src/main/java/com/teachtouch/backend/guide/repository/GuideRepository.java
@@ -1,0 +1,9 @@
+package com.teachtouch.backend.guide.repository;
+
+import com.teachtouch.backend.guide.entity.Guide;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GuideRepository extends JpaRepository<Guide,Long> {
+}

--- a/src/main/java/com/teachtouch/backend/guide/service/GuideService.java
+++ b/src/main/java/com/teachtouch/backend/guide/service/GuideService.java
@@ -1,0 +1,8 @@
+package com.teachtouch.backend.guide.service;
+
+import com.teachtouch.backend.guide.dto.GuideRequestDTO;
+import com.teachtouch.backend.guide.entity.Guide;
+
+public interface GuideService {
+    Guide upsertGuide(GuideRequestDTO dto);
+}

--- a/src/main/java/com/teachtouch/backend/guide/service/GuideServiceImpl.java
+++ b/src/main/java/com/teachtouch/backend/guide/service/GuideServiceImpl.java
@@ -1,0 +1,99 @@
+package com.teachtouch.backend.guide.service;
+
+import com.teachtouch.backend.example.dto.ExampleRequestDTO;
+import com.teachtouch.backend.guide.dto.GuideRequestDTO;
+import com.teachtouch.backend.guide.dto.StepRequestDTO;
+import com.teachtouch.backend.guide.entity.Guide;
+import com.teachtouch.backend.guide.entity.GuideExample;
+import com.teachtouch.backend.guide.entity.GuideProduct;
+import com.teachtouch.backend.guide.entity.Step;
+import com.teachtouch.backend.guide.repository.GuideRepository;
+import com.teachtouch.backend.product.entity.Product;
+import com.teachtouch.backend.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GuideServiceImpl implements GuideService {
+
+    private final GuideRepository guideRepository;
+    private final ProductRepository productRepository;
+
+    @Override
+    public Guide upsertGuide(GuideRequestDTO dto) {
+        Guide guide = (dto.id() != null)
+                ? guideRepository.findById(dto.id())
+                .orElseThrow(() -> new IllegalArgumentException("가이드가 존재하지 않음: " + dto.id()))
+                : new Guide();
+
+        guide.setTitle(dto.title());
+        guide.setCategory(dto.category());
+        guide.setDescription(dto.description());
+
+
+        guide.getProducts().clear();
+        guide.getExamples().clear();
+        guide.getSteps().clear();
+
+
+        if (dto.productIds() != null) {
+            for (Long productId : dto.productIds()) {
+                Product product = productRepository.findById(productId)
+                        .orElseThrow(() -> new IllegalArgumentException("상품이 존재하지 않음: " + productId));
+
+                GuideProduct gp = new GuideProduct();
+                gp.setProduct(product);
+                gp.setGuide(guide);
+                guide.getProducts().add(gp);
+            }
+        }
+
+
+        if (dto.examples() != null) {
+            for (ExampleRequestDTO exDto : dto.examples()) {
+                Product product = productRepository.findById(exDto.productId())
+                        .orElseThrow(() -> new IllegalArgumentException("상품이 존재하지 않음: " + exDto.productId()));
+
+                GuideExample example = new GuideExample();
+                example.setProduct(product);
+                example.setQuantity(exDto.quantity());
+                example.setGuide(guide);
+                guide.getExamples().add(example);
+            }
+        }
+
+
+        if (dto.steps() != null) {
+            for (StepRequestDTO stepDto : dto.steps()) {
+                Step step = mapStepDtoToEntity(stepDto, guide, null);
+                guide.getSteps().add(step);
+            }
+        }
+
+        return guideRepository.save(guide);
+    }
+
+
+    private Step mapStepDtoToEntity(StepRequestDTO dto, Guide guide, Step parent) {
+        Step step = new Step();
+        step.setStepCode(dto.stepCode());
+        step.setTitle(dto.title());
+        step.setType(dto.type());
+        step.setContent(dto.content());
+        step.setMetadata(dto.metadata());
+        step.setGuide(guide);
+        step.setParent(parent);
+
+        if (dto.subSteps() != null) {
+            for (StepRequestDTO subStepDto : dto.subSteps()) {
+                Step subStep = mapStepDtoToEntity(subStepDto, guide, step);
+                step.getSubSteps().add(subStep);
+            }
+        }
+
+        return step;
+    }
+}

--- a/src/main/java/com/teachtouch/backend/product/controller/ProductController.java
+++ b/src/main/java/com/teachtouch/backend/product/controller/ProductController.java
@@ -1,0 +1,37 @@
+package com.teachtouch.backend.product.controller;
+
+import com.teachtouch.backend.product.dto.ProductRequestDTO;
+import com.teachtouch.backend.product.dto.ProductResponseDTO;
+import com.teachtouch.backend.product.entity.Product;
+import com.teachtouch.backend.product.service.ProductService;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1.0/products")
+@RequiredArgsConstructor
+public class ProductController {
+    private final ProductService productService;
+
+
+    @PostMapping
+    public ResponseEntity<Long> createOne(@RequestBody ProductRequestDTO dto) {
+        Long id = productService.create(dto);
+        return ResponseEntity.ok(id);
+    }
+
+
+    @PostMapping("/batch")
+    public ResponseEntity<List<Long>> createMultiple(@RequestBody List<ProductRequestDTO> dtos) {
+        List<Long> ids = productService.createAll(dtos);
+        return ResponseEntity.ok(ids);
+    }
+}

--- a/src/main/java/com/teachtouch/backend/product/dto/ProductRequestDTO.java
+++ b/src/main/java/com/teachtouch/backend/product/dto/ProductRequestDTO.java
@@ -1,0 +1,9 @@
+package com.teachtouch.backend.product.dto;
+
+public record ProductRequestDTO(
+        String name,
+        String imageUrl,
+        String category,
+        int price
+) {
+}

--- a/src/main/java/com/teachtouch/backend/product/dto/ProductResponseDTO.java
+++ b/src/main/java/com/teachtouch/backend/product/dto/ProductResponseDTO.java
@@ -1,0 +1,21 @@
+package com.teachtouch.backend.product.dto;
+
+import com.teachtouch.backend.product.entity.Product;
+
+public record ProductResponseDTO(
+        Long id,
+        String name,
+        String imageUrl,
+        String category,
+        int price
+) {
+    public static ProductResponseDTO fromEntity(Product product){
+        return new ProductResponseDTO(
+                product.getId(),
+                product.getName(),
+                product.getImageUrl(),
+                product.getCategory(),
+                product.getPrice()
+        );
+    }
+}

--- a/src/main/java/com/teachtouch/backend/product/entity/Product.java
+++ b/src/main/java/com/teachtouch/backend/product/entity/Product.java
@@ -1,0 +1,25 @@
+package com.teachtouch.backend.product.entity;
+
+import com.teachtouch.backend.guide.entity.Guide;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "products")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String imageUrl;
+    private String category;
+    private int price;
+
+}

--- a/src/main/java/com/teachtouch/backend/product/repository/ProductRepository.java
+++ b/src/main/java/com/teachtouch/backend/product/repository/ProductRepository.java
@@ -1,0 +1,9 @@
+package com.teachtouch.backend.product.repository;
+
+import com.teachtouch.backend.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product,Long> {
+}

--- a/src/main/java/com/teachtouch/backend/product/service/ProductService.java
+++ b/src/main/java/com/teachtouch/backend/product/service/ProductService.java
@@ -1,0 +1,10 @@
+package com.teachtouch.backend.product.service;
+
+import com.teachtouch.backend.product.dto.ProductRequestDTO;
+
+import java.util.List;
+
+public interface ProductService {
+    Long create(ProductRequestDTO dto);
+    List<Long> createAll(List<ProductRequestDTO> dtos);
+}

--- a/src/main/java/com/teachtouch/backend/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/teachtouch/backend/product/service/ProductServiceImpl.java
@@ -1,0 +1,43 @@
+package com.teachtouch.backend.product.service;
+
+import com.teachtouch.backend.product.dto.ProductRequestDTO;
+import com.teachtouch.backend.product.entity.Product;
+import com.teachtouch.backend.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProductServiceImpl implements ProductService {
+
+    private final ProductRepository productRepository;
+
+    @Override
+    public Long create(ProductRequestDTO dto) {
+        Product product = toEntity(dto);
+        return productRepository.save(product).getId();
+    }
+
+    @Override
+    public List<Long> createAll(List<ProductRequestDTO> dtos) {
+        List<Product> products = dtos.stream()
+                .map(this::toEntity)
+                .collect(Collectors.toList());
+        productRepository.saveAll(products);
+        return products.stream().map(Product::getId).toList();
+    }
+
+    private Product toEntity(ProductRequestDTO dto) {
+        return Product.builder()
+                .name(dto.name())
+                .category(dto.category())
+                .imageUrl(dto.imageUrl())
+                .price(dto.price())
+                .build();
+    }
+}


### PR DESCRIPTION


## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #3` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

- 가이드 생성(수정) API를 구현하기 위해 Product, Example을 생성할 수 있는 간단한 코드를 구축했습니다.
- Example은 가이드에서 사용할 예시 주문 목록입니다. 현재는 가이드를 생성할 때 inline으로 추가하며, 추후 Example만 따로 생성하여 이용하는 방식을 열어두고 구현해놓았습니다.
- 가이드를 생성하기 전 가이드에 사용할 Product들을 미리 생성해야 합니다.
->단일 생성/다중 생성이 가능합니다.

- 현재 관리자가 없기 때문에 각 엔드포인트가 permitAll 상태입니다. 추후 리팩토링 필요합니다.
- 
**- ** 가이드 생성은 "upsert" 방식으로 구현되었기 때문에, 없으면 생성, 있으면 수정됩니다.**

가이드 구성은 기본적으로 기획의 Flow을 따릅니다.

- title | 가이드 제목
- category | 키오스크, 카페, 결제 등 주제 분류
- description | 전체 가이드에 대한 개요 설명
- steps | 학습 단계를 의미하며, 순차적 구조로 구성됨
- stepCode | 각 스텝을 식별할 수 있는 코드 (1, 2-1, 3-3 등)
- type | 스텝 유형 (text, product-grid, choice)
- content | 학습에 필요한 설명 텍스트 (markdown 형식 가능)
- productIds | 이 스텝에서 사용하는 상품들의 ID 목록
- examples | 실습용 주문 예시 (productId, quantity 조합)
- metadata | 선택형 스텝에서 옵션 리스트 (label, hint, description)


## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등


## #️⃣ 스크린샷 (선택)
<img width="1893" height="1022" alt="image" src="https://github.com/user-attachments/assets/a7376d6a-57ae-4ac8-bb0c-1a7a306037fd" />

<img width="1895" height="928" alt="image" src="https://github.com/user-attachments/assets/5e637010-3708-4466-aecd-1b8a4c4647c2" />

<img width="1466" height="396" alt="image" src="https://github.com/user-attachments/assets/4c6df6ff-e881-4faa-a2ec-f2a6a41027a6" />


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요