### PR TITLE
feat : 가이드 조회 & 삭제 기능 추가

### DIFF
--- a/src/main/java/com/teachtouch/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/teachtouch/backend/global/config/SecurityConfig.java
@@ -38,6 +38,8 @@ public class SecurityConfig {
                                 "/api/v1.0/products/batch",
                                 "/api/v1.0/examples",
                                 "/api/v1.0/guides",
+                                "/api/v1.0/guides/{id}",
+                                "/api/v1.0/guides/search",
                                 "/oauth2/**"
 
                         ).permitAll()

--- a/src/main/java/com/teachtouch/backend/guide/controller/GuideController.java
+++ b/src/main/java/com/teachtouch/backend/guide/controller/GuideController.java
@@ -11,7 +11,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1.0/guides")
@@ -75,6 +77,18 @@ public class GuideController {
         List<String> completed = guideService.getCompletedStepCodes(userId);
         return ResponseEntity.ok(completed);
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Map<String, String>> deleteGuide(@PathVariable Long id) {
+        guideService.deleteGuide(id);
+
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "가이드가 성공적으로 삭제되었습니다.");
+
+        return ResponseEntity.ok(response);
+    }
+
+
 
 
 }

--- a/src/main/java/com/teachtouch/backend/guide/controller/GuideController.java
+++ b/src/main/java/com/teachtouch/backend/guide/controller/GuideController.java
@@ -1,15 +1,17 @@
 package com.teachtouch.backend.guide.controller;
 
+import com.teachtouch.backend.global.security.CustomUserDetails;
 import com.teachtouch.backend.guide.dto.GuideRequestDTO;
 import com.teachtouch.backend.guide.dto.GuideResponseDTO;
 import com.teachtouch.backend.guide.entity.Guide;
 import com.teachtouch.backend.guide.service.GuideService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1.0/guides")
@@ -19,8 +21,60 @@ public class GuideController {
     private final GuideService guideService;
 
     @PostMapping
-    public ResponseEntity<GuideResponseDTO>upsertGuide(@RequestBody GuideRequestDTO dto){
+    public ResponseEntity<GuideResponseDTO> upsertGuide(@RequestBody GuideRequestDTO dto) {
         Guide saved = guideService.upsertGuide(dto);
-        return ResponseEntity.ok(GuideResponseDTO.fromEntity(saved));
+        return ResponseEntity.ok(GuideResponseDTO.fromEntity(saved, true));
     }
+    /* 전체 조회 : 가이드 list 조회 */
+    @GetMapping
+    public ResponseEntity<List<GuideResponseDTO>> getAllGuides() {
+        List<Guide> guides = guideService.findAll();
+        return ResponseEntity.ok(
+                guides.stream()
+                        .map(g -> GuideResponseDTO.fromEntity(g, false))
+                        .toList()
+        );
+    }
+
+    /* 단일 조회 : 각 가이드 본문 조회 */
+    @GetMapping("/{id}")
+    public ResponseEntity<GuideResponseDTO> getGuideDetail(@PathVariable Long id) {
+        Guide guide = guideService.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 가이드: " + id));
+        return ResponseEntity.ok(GuideResponseDTO.fromEntity(guide, true));
+    }
+
+    /* 가이드를 카테고리를 통해 조회 */
+    @GetMapping("/search")
+    public ResponseEntity<List<GuideResponseDTO>> searchGuides(@RequestParam String keyword) {
+        List<Guide> guides = guideService.searchByKeyword(keyword);
+        return ResponseEntity.ok(
+                guides.stream()
+                        .map(g -> GuideResponseDTO.fromEntity(g, false))
+                        .toList()
+        );
+    }
+
+    /* 가이드의 각 step 완수 완료 저장 */
+    @PostMapping("/steps/{stepId}/complete")
+    public ResponseEntity<Void> completeStep(@PathVariable Long stepId,
+                                             @AuthenticationPrincipal UserDetails user) {
+        Long userId = ((CustomUserDetails) user).getUser().getId();
+        guideService.markStepAsCompleted(stepId, userId);
+        return ResponseEntity.ok().build();
+    }
+
+
+    /* 해당 가이드의 완수된 step 조회 */
+    @GetMapping("/{guideId}/steps/progress")
+    public ResponseEntity<List<String>> getUserCompletedSteps(
+            @PathVariable Long guideId,
+            @AuthenticationPrincipal CustomUserDetails user) {
+
+        Long userId = user.getUser().getId();
+        List<String> completed = guideService.getCompletedStepCodes(userId);
+        return ResponseEntity.ok(completed);
+    }
+
+
 }

--- a/src/main/java/com/teachtouch/backend/guide/dto/GuideResponseDTO.java
+++ b/src/main/java/com/teachtouch/backend/guide/dto/GuideResponseDTO.java
@@ -1,19 +1,29 @@
 package com.teachtouch.backend.guide.dto;
 
 import com.teachtouch.backend.guide.entity.Guide;
+import com.teachtouch.backend.guide.entity.Step;
+
+import java.util.List;
 
 public record GuideResponseDTO(
         Long id,
         String title,
         String category,
-        String description
+        String description,
+        List<StepResponseDTO> steps
 ) {
-    public static GuideResponseDTO fromEntity(Guide guide){
+    public static GuideResponseDTO fromEntity(Guide guide, boolean includeSteps) {
         return new GuideResponseDTO(
                 guide.getId(),
                 guide.getTitle(),
                 guide.getCategory(),
-                guide.getDescription()
+                guide.getDescription(),
+                includeSteps
+                        ? guide.getSteps().stream()
+                        .filter(step -> step.getParent() == null)
+                        .map(StepResponseDTO::fromEntity)
+                        .toList()
+                        : null
         );
     }
 }

--- a/src/main/java/com/teachtouch/backend/guide/dto/StepResponseDTO.java
+++ b/src/main/java/com/teachtouch/backend/guide/dto/StepResponseDTO.java
@@ -1,0 +1,30 @@
+package com.teachtouch.backend.guide.dto;
+
+import com.teachtouch.backend.guide.entity.Step;
+
+import java.util.List;
+import java.util.Map;
+
+public record StepResponseDTO(
+        Long id,
+        String stepCode,
+        String title,
+        String type,
+        String content,
+        Map<String, Object> metadata,
+        List<StepResponseDTO> subSteps
+) {
+    public static StepResponseDTO fromEntity(Step step) {
+        return new StepResponseDTO(
+                step.getId(),
+                step.getStepCode(),
+                step.getTitle(),
+                step.getType(),
+                step.getContent(),
+                step.getMetadata(),
+                step.getSubSteps().stream()
+                        .map(StepResponseDTO::fromEntity)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/teachtouch/backend/guide/entity/Guide.java
+++ b/src/main/java/com/teachtouch/backend/guide/entity/Guide.java
@@ -26,14 +26,15 @@ public class Guide {
     private String category;
     private String description;
 
-    @OneToMany(mappedBy = "guide")
-    private List<GuideProduct> products = new ArrayList<>();
-
-    @OneToMany(mappedBy = "guide")
-    private List<GuideExample> examples = new ArrayList<>();
-
     @OneToMany(mappedBy = "guide", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Step> steps = new ArrayList<>();
+
+    @OneToMany(mappedBy = "guide", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<GuideProduct> products = new ArrayList<>();
+
+    @OneToMany(mappedBy = "guide", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<GuideExample> examples = new ArrayList<>();
+
 
     @CreatedDate
     private LocalDateTime createdAt;

--- a/src/main/java/com/teachtouch/backend/guide/entity/Step.java
+++ b/src/main/java/com/teachtouch/backend/guide/entity/Step.java
@@ -39,5 +39,9 @@ public class Step {
     @Column(columnDefinition = "json")
     @Convert(converter = MetadataConverter.class)
     private Map<String,Object> metadata;
+
+    @OneToMany(mappedBy = "step", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<StepProgress> progresses = new ArrayList<>();
+
 }
 

--- a/src/main/java/com/teachtouch/backend/guide/entity/StepProgress.java
+++ b/src/main/java/com/teachtouch/backend/guide/entity/StepProgress.java
@@ -1,0 +1,27 @@
+package com.teachtouch.backend.guide.entity;
+
+import com.teachtouch.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StepProgress {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Step step;
+
+    @Column(nullable = false)
+    private boolean completed = false;
+}

--- a/src/main/java/com/teachtouch/backend/guide/repository/GuideRepository.java
+++ b/src/main/java/com/teachtouch/backend/guide/repository/GuideRepository.java
@@ -4,6 +4,8 @@ import com.teachtouch.backend.guide.entity.Guide;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
-public interface GuideRepository extends JpaRepository<Guide,Long> {
+import java.util.List;
+
+public interface GuideRepository extends JpaRepository<Guide, Long> {
+    List<Guide> findByTitleContainingIgnoreCaseOrCategoryContainingIgnoreCase(String title, String category);
 }

--- a/src/main/java/com/teachtouch/backend/guide/repository/StepProgressRepository.java
+++ b/src/main/java/com/teachtouch/backend/guide/repository/StepProgressRepository.java
@@ -1,0 +1,16 @@
+package com.teachtouch.backend.guide.repository;
+
+import com.teachtouch.backend.guide.entity.Step;
+import com.teachtouch.backend.guide.entity.StepProgress;
+import com.teachtouch.backend.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StepProgressRepository extends JpaRepository<StepProgress, Long> {
+
+    Optional<StepProgress> findByUserAndStep(User user, Step step);
+
+    List<StepProgress> findByUser(User user);
+}

--- a/src/main/java/com/teachtouch/backend/guide/repository/StepRepository.java
+++ b/src/main/java/com/teachtouch/backend/guide/repository/StepRepository.java
@@ -1,0 +1,7 @@
+package com.teachtouch.backend.guide.repository;
+
+import com.teachtouch.backend.guide.entity.Step;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StepRepository extends JpaRepository<Step,Long> {
+}

--- a/src/main/java/com/teachtouch/backend/guide/service/GuideService.java
+++ b/src/main/java/com/teachtouch/backend/guide/service/GuideService.java
@@ -16,4 +16,6 @@ public interface GuideService {
 
     List<String> getCompletedStepCodes(Long userId);
 
+    void deleteGuide(Long guideId);
+
 }

--- a/src/main/java/com/teachtouch/backend/guide/service/GuideService.java
+++ b/src/main/java/com/teachtouch/backend/guide/service/GuideService.java
@@ -3,6 +3,17 @@ package com.teachtouch.backend.guide.service;
 import com.teachtouch.backend.guide.dto.GuideRequestDTO;
 import com.teachtouch.backend.guide.entity.Guide;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface GuideService {
     Guide upsertGuide(GuideRequestDTO dto);
+    List<Guide> findAll();
+    Optional<Guide> findById(Long id);
+    List<Guide> searchByKeyword(String keyword);
+
+    void markStepAsCompleted(Long stepId, Long userId);
+
+    List<String> getCompletedStepCodes(Long userId);
+
 }

--- a/src/main/java/com/teachtouch/backend/guide/service/GuideServiceImpl.java
+++ b/src/main/java/com/teachtouch/backend/guide/service/GuideServiceImpl.java
@@ -3,16 +3,20 @@ package com.teachtouch.backend.guide.service;
 import com.teachtouch.backend.example.dto.ExampleRequestDTO;
 import com.teachtouch.backend.guide.dto.GuideRequestDTO;
 import com.teachtouch.backend.guide.dto.StepRequestDTO;
-import com.teachtouch.backend.guide.entity.Guide;
-import com.teachtouch.backend.guide.entity.GuideExample;
-import com.teachtouch.backend.guide.entity.GuideProduct;
-import com.teachtouch.backend.guide.entity.Step;
+import com.teachtouch.backend.guide.entity.*;
 import com.teachtouch.backend.guide.repository.GuideRepository;
+import com.teachtouch.backend.guide.repository.StepProgressRepository;
+import com.teachtouch.backend.guide.repository.StepRepository;
 import com.teachtouch.backend.product.entity.Product;
 import com.teachtouch.backend.product.repository.ProductRepository;
+import com.teachtouch.backend.user.entity.User;
+import com.teachtouch.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +25,9 @@ public class GuideServiceImpl implements GuideService {
 
     private final GuideRepository guideRepository;
     private final ProductRepository productRepository;
+    private final StepProgressRepository stepProgressRepository;
+    private final StepRepository stepRepository;
+    private final UserRepository userRepository;
 
     @Override
     public Guide upsertGuide(GuideRequestDTO dto) {
@@ -96,4 +103,50 @@ public class GuideServiceImpl implements GuideService {
 
         return step;
     }
+
+
+    @Override
+    public List<Guide> findAll() {
+        return guideRepository.findAll();
+    }
+
+    @Override
+    public Optional<Guide> findById(Long id) {
+        return guideRepository.findById(id);
+    }
+
+    @Override
+    public List<Guide> searchByKeyword(String keyword) {
+        return guideRepository.findByTitleContainingIgnoreCaseOrCategoryContainingIgnoreCase(keyword, keyword);
+    }
+
+    @Override
+    public void markStepAsCompleted(Long stepId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저 없음: " + userId));
+        Step step = stepRepository.findById(stepId)
+                .orElseThrow(() -> new IllegalArgumentException("단계 없음: " + stepId));
+
+        StepProgress progress = stepProgressRepository.findByUserAndStep(user, step)
+                .orElse(StepProgress.builder()
+                        .user(user)
+                        .step(step)
+                        .completed(true)
+                        .build());
+
+        progress.setCompleted(true);
+        stepProgressRepository.save(progress);
+    }
+
+    @Override
+    public List<String> getCompletedStepCodes(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저 없음: " + userId));
+        return stepProgressRepository.findByUser(user).stream()
+                .filter(StepProgress::isCompleted)
+                .map(progress -> progress.getStep().getStepCode())
+                .toList();
+    }
+
+
 }

--- a/src/main/java/com/teachtouch/backend/guide/service/GuideServiceImpl.java
+++ b/src/main/java/com/teachtouch/backend/guide/service/GuideServiceImpl.java
@@ -147,6 +147,13 @@ public class GuideServiceImpl implements GuideService {
                 .map(progress -> progress.getStep().getStepCode())
                 .toList();
     }
+    @Override
+    public void deleteGuide(Long guideId) {
+        Guide guide = guideRepository.findById(guideId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 가이드를 찾을 수 없습니다: " + guideId));
+        guideRepository.delete(guide);
+    }
+
 
 
 }


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #8` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

- 생성한 가이드를 리스트 조회(전체 조회), 단일 조회(각 가이드 본문 조회) 할 수 있으며 카테고리 키워드 별로 조회할 수 있는 기능을 추가하였습니다.
- 생성한 가이드를 삭제할 수 있는 기능을 추가하였습니다.
- 기획 및 디자인 수정에 따라, 각 step 별 학습 여부를 사용자 별로 complete할 수 있는 API를 추가하였습니다.
- 이에 따라 학습여부를 확인할 수 있는 progress 관련 API도 추가하였습니다.
- 
## #️⃣ 테스트 결과

모든 테스트 통과 (Postman)

## #️⃣ 스크린샷 (선택)

1. 가이드 전체 조회 ( 리스트를 조회)
<img width="1146" height="1039" alt="image" src="https://github.com/user-attachments/assets/359937d3-4942-4744-80ad-ddd53019dc27" />

2. 가이드 단일 조회 ( 각 가이드의 본문 조회 )
<img width="1857" height="1276" alt="image" src="https://github.com/user-attachments/assets/46dfb23e-e7ed-442d-a0ce-7507713ac468" />

3. 카테고리 키워드 별 조회
<img width="1914" height="572" alt="image" src="https://github.com/user-attachments/assets/ffc5fbc9-cae5-474a-9c7a-59d4bc9f0f57" />

4. 가이드 삭제
<img width="1888" height="859" alt="image" src="https://github.com/user-attachments/assets/c4606ded-b840-4851-9962-aae13df8a3d6" />

5. 학습 여부 complete
<img width="1904" height="821" alt="image" src="https://github.com/user-attachments/assets/505f643d-edbb-4024-84cc-3b7082cccbbc" />

6. 학습 여부 조회 progress
<img width="1885" height="1015" alt="image" src="https://github.com/user-attachments/assets/a4676e11-7742-45ee-bbd5-d411badf9288" />


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요