### PR TITLE
feat: 학습 완료 개별 API 추가 및 기존 API 수정

### DIFF
--- a/src/main/java/com/teachtouch/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/teachtouch/backend/global/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                                 "/api/v1.0/products",
                                 "/api/v1.0/products/batch",
                                 "/api/v1.0/examples",
-                                "/api/v1.0/guides",
+                                "/api/v1.0/guides/**",
                                 "/api/v1.0/guides/{id}",
                                 "/api/v1.0/guides/search",
                                 "/oauth2/**",
@@ -45,6 +45,7 @@ public class SecurityConfig {
                                 "/api/v1.0/retouch/test/all",
                                 "/api/v1.0/retouch/test/add",
                                 "/api/v1.0/retouch/test/**"
+
 
                         ).permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/teachtouch/backend/guide/controller/GuideController.java
+++ b/src/main/java/com/teachtouch/backend/guide/controller/GuideController.java
@@ -11,9 +11,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @RestController
 @RequestMapping("/api/v1.0/guides")
@@ -22,31 +20,60 @@ public class GuideController {
 
     private final GuideService guideService;
 
+
     @PostMapping
     public ResponseEntity<GuideResponseDTO> upsertGuide(@RequestBody GuideRequestDTO dto) {
         Guide saved = guideService.upsertGuide(dto);
         return ResponseEntity.ok(GuideResponseDTO.fromEntity(saved, true));
     }
-    /* 전체 조회 : 가이드 list 조회 */
+
+    /* 가이드 전체 조회  */
     @GetMapping
-    public ResponseEntity<List<GuideResponseDTO>> getAllGuides() {
+    public ResponseEntity<List<GuideResponseDTO>> getAllGuides(
+            @AuthenticationPrincipal CustomUserDetails principal
+    ) {
         List<Guide> guides = guideService.findAll();
-        return ResponseEntity.ok(
-                guides.stream()
-                        .map(g -> GuideResponseDTO.fromEntity(g, false))
-                        .toList()
-        );
+        Map<Long, Boolean> completedMap;
+        if (principal != null) {
+            Long userId = principal.getUser().getId();
+            List<Long> ids = guides.stream().map(Guide::getId).toList();
+            completedMap = guideService.areGuidesCompleted(userId, ids);
+        } else {
+            completedMap = Collections.emptyMap();
+        }
+
+        final Map<Long, Boolean> finalCompletedMap = completedMap;
+
+        List<GuideResponseDTO> response = guides.stream()
+                .map(g -> {
+                    boolean completed = finalCompletedMap.getOrDefault(g.getId(), false);
+                    return GuideResponseDTO.fromEntity(g, false, completed);
+                })
+                .toList();
+
+
+        return ResponseEntity.ok(response);
     }
 
-    /* 단일 조회 : 각 가이드 본문 조회 */
+    /* 가이드 단일 조회  user별 completed 포함 */
     @GetMapping("/{id}")
-    public ResponseEntity<GuideResponseDTO> getGuideDetail(@PathVariable Long id) {
+    public ResponseEntity<GuideResponseDTO> getGuideDetail(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails principal
+    ) {
         Guide guide = guideService.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 가이드: " + id));
-        return ResponseEntity.ok(GuideResponseDTO.fromEntity(guide, true));
+
+        boolean completed = false;
+        if (principal != null) {
+            Long userId = principal.getUser().getId();
+            completed = guideService.isGuideCompleted(userId, id);
+        }
+
+        return ResponseEntity.ok(GuideResponseDTO.fromEntity(guide, true, completed));
     }
 
-    /* 가이드를 카테고리를 통해 조회 */
+    /* 가이드 검색 */
     @GetMapping("/search")
     public ResponseEntity<List<GuideResponseDTO>> searchGuides(@RequestParam String keyword) {
         List<Guide> guides = guideService.searchByKeyword(keyword);
@@ -57,7 +84,7 @@ public class GuideController {
         );
     }
 
-    /* 가이드의 각 step 완수 완료 저장 */
+    /* Step 단위 완료 저장 */
     @PostMapping("/steps/{stepId}/complete")
     public ResponseEntity<Void> completeStep(@PathVariable Long stepId,
                                              @AuthenticationPrincipal UserDetails user) {
@@ -66,8 +93,7 @@ public class GuideController {
         return ResponseEntity.ok().build();
     }
 
-
-    /* 해당 가이드의 완수된 step 조회 */
+    /* Step 단위 완료 조회 */
     @GetMapping("/{guideId}/steps/progress")
     public ResponseEntity<List<String>> getUserCompletedSteps(
             @PathVariable Long guideId,
@@ -78,6 +104,29 @@ public class GuideController {
         return ResponseEntity.ok(completed);
     }
 
+    /* Guide 단위 완료 저장 */
+    @PostMapping("/{guideId}/complete")
+    public ResponseEntity<Void> completeGuide(
+            @PathVariable Long guideId,
+            @AuthenticationPrincipal CustomUserDetails user) {
+
+        Long userId = user.getUser().getId();
+        guideService.markGuideAsCompleted(guideId, userId);
+        return ResponseEntity.ok().build();
+    }
+
+    /* Guide 단위 완료 여부 조회 */
+    @GetMapping("/{guideId}/progress")
+    public ResponseEntity<Boolean> isGuideCompleted(
+            @PathVariable Long guideId,
+            @AuthenticationPrincipal CustomUserDetails user) {
+
+        Long userId = user.getUser().getId();
+        boolean completed = guideService.isGuideCompleted(userId, guideId);
+        return ResponseEntity.ok(completed);
+    }
+
+    /* 가이드 삭제 */
     @DeleteMapping("/{id}")
     public ResponseEntity<Map<String, String>> deleteGuide(@PathVariable Long id) {
         guideService.deleteGuide(id);
@@ -87,8 +136,4 @@ public class GuideController {
 
         return ResponseEntity.ok(response);
     }
-
-
-
-
 }

--- a/src/main/java/com/teachtouch/backend/guide/dto/GuideResponseDTO.java
+++ b/src/main/java/com/teachtouch/backend/guide/dto/GuideResponseDTO.java
@@ -1,7 +1,6 @@
 package com.teachtouch.backend.guide.dto;
 
 import com.teachtouch.backend.guide.entity.Guide;
-import com.teachtouch.backend.guide.entity.Step;
 
 import java.util.List;
 
@@ -10,6 +9,7 @@ public record GuideResponseDTO(
         String title,
         String category,
         String description,
+        Boolean completed,               
         List<StepResponseDTO> steps
 ) {
     public static GuideResponseDTO fromEntity(Guide guide, boolean includeSteps) {
@@ -18,6 +18,22 @@ public record GuideResponseDTO(
                 guide.getTitle(),
                 guide.getCategory(),
                 guide.getDescription(),
+                false, // 기본값
+                includeSteps
+                        ? guide.getSteps().stream()
+                        .filter(step -> step.getParent() == null)
+                        .map(StepResponseDTO::fromEntity)
+                        .toList()
+                        : null
+        );
+    }
+    public static GuideResponseDTO fromEntity(Guide guide, boolean includeSteps, boolean completed) {
+        return new GuideResponseDTO(
+                guide.getId(),
+                guide.getTitle(),
+                guide.getCategory(),
+                guide.getDescription(),
+                completed,
                 includeSteps
                         ? guide.getSteps().stream()
                         .filter(step -> step.getParent() == null)

--- a/src/main/java/com/teachtouch/backend/guide/entity/GuideProgress.java
+++ b/src/main/java/com/teachtouch/backend/guide/entity/GuideProgress.java
@@ -1,0 +1,31 @@
+package com.teachtouch.backend.guide.entity;
+import com.teachtouch.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "guide_progress",
+        uniqueConstraints = @UniqueConstraint(name = "uk_user_guide", columnNames = {"user_id", "guide_id"})
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GuideProgress {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Guide guide;
+
+    @Column(nullable = false)
+    private boolean completed = false;
+}
+

--- a/src/main/java/com/teachtouch/backend/guide/repository/GuideProgressRepository.java
+++ b/src/main/java/com/teachtouch/backend/guide/repository/GuideProgressRepository.java
@@ -1,0 +1,16 @@
+package com.teachtouch.backend.guide.repository;
+
+import com.teachtouch.backend.guide.entity.Guide;
+import com.teachtouch.backend.guide.entity.GuideProgress;
+import com.teachtouch.backend.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GuideProgressRepository extends JpaRepository<GuideProgress, Long> {
+    Optional<GuideProgress> findByUserAndGuide(User user, Guide guide);
+
+    List<GuideProgress> findByUserAndGuide_IdIn(User user, List<Long> guideIds);
+}
+

--- a/src/main/java/com/teachtouch/backend/guide/service/GuideService.java
+++ b/src/main/java/com/teachtouch/backend/guide/service/GuideService.java
@@ -4,6 +4,7 @@ import com.teachtouch.backend.guide.dto.GuideRequestDTO;
 import com.teachtouch.backend.guide.entity.Guide;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface GuideService {
@@ -11,11 +12,12 @@ public interface GuideService {
     List<Guide> findAll();
     Optional<Guide> findById(Long id);
     List<Guide> searchByKeyword(String keyword);
-
     void markStepAsCompleted(Long stepId, Long userId);
-
     List<String> getCompletedStepCodes(Long userId, Long guideId);
 
+    // 추가
+    boolean isGuideCompleted(Long userId, Long guideId);
+    Map<Long, Boolean> areGuidesCompleted(Long userId, List<Long> guideIds);
+    void markGuideAsCompleted(Long guideId, Long userId); // 추후 전용 API용
     void deleteGuide(Long guideId);
-
 }


### PR DESCRIPTION


## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #16 ` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

- 프론트의 요청에 따라 가이드를 유저별로 조회 시 complete 여부가 나오도록 수정했습니다.
- 프론트의 개발 작업 편의를 위해 유저별 학습 완료 API를 저장 /조회 할 수 있는 API도 추가했습니다.
## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등


## #️⃣ 스크린샷 (선택)

<img width="1866" height="1283" alt="image" src="https://github.com/user-attachments/assets/08330689-73de-439d-bcd3-69b9f7d34af7" />
<img width="1895" height="1016" alt="image" src="https://github.com/user-attachments/assets/84f9c2c9-8ea3-493c-bafe-0ed154811afb" />

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요