### PR TITLE
feat: 리터치 틀린 문제 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/teachtouch/backend/retouch/controller/RetouchController.java
+++ b/src/main/java/com/teachtouch/backend/retouch/controller/RetouchController.java
@@ -70,4 +70,12 @@ public class RetouchController {
         return ResponseEntity.ok(result);
     }
 
+    @GetMapping("/wrong")
+    public ResponseEntity<List<WrongTestDto>> getWrongTests(HttpServletRequest request) {
+        String LoginId = userService.getLoginIdFromToken(request.getHeader("Authorization"));
+        Long userId = userService.getUserIdByLoginId(LoginId);
+        List<WrongTestDto> wrongTests = retouchService.getWrongTests(userId);
+        return ResponseEntity.ok(wrongTests);
+    }
+
 }

--- a/src/main/java/com/teachtouch/backend/retouch/dto/WrongTestDto.java
+++ b/src/main/java/com/teachtouch/backend/retouch/dto/WrongTestDto.java
@@ -1,0 +1,17 @@
+package com.teachtouch.backend.retouch.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WrongTestDto {
+    private Long testId; //테스트ID
+    private Long solveHistoryId; //히스토리ID
+    private String testTitle; //테스트 제목
+    private LocalDateTime testDate; //풀이한 날짜
+}

--- a/src/main/java/com/teachtouch/backend/retouch/entity/SolveHistory.java
+++ b/src/main/java/com/teachtouch/backend/retouch/entity/SolveHistory.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -14,6 +15,7 @@ import java.util.List;
 @Entity
 @Getter
 @Setter
+@EntityListeners(AuditingEntityListener.class)
 public class SolveHistory {
 
     @Id

--- a/src/main/java/com/teachtouch/backend/retouch/repository/SolveHistoryRepository.java
+++ b/src/main/java/com/teachtouch/backend/retouch/repository/SolveHistoryRepository.java
@@ -2,10 +2,12 @@ package com.teachtouch.backend.retouch.repository;
 
 import com.teachtouch.backend.retouch.entity.SolveHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface SolveHistoryRepository extends JpaRepository<SolveHistory, Long> {
     List<SolveHistory> findByUserIdAndTestId(Long userId, Long testId);
-    List<SolveHistory> findByUserId(Long userId);
+    List<SolveHistory> findByUserIdOrderByCreatedDateDesc(Long userId);
 }

--- a/src/main/java/com/teachtouch/backend/retouch/service/RetouchService.java
+++ b/src/main/java/com/teachtouch/backend/retouch/service/RetouchService.java
@@ -19,4 +19,6 @@ public interface RetouchService {
     List<TestProgressResponseDto> getAllTestProgress(Long userId);
 
     TestResultDto submitTest(Long userId, TestSubmitDto submitDto);
+
+    List<WrongTestDto> getWrongTests(Long userId);
 }


### PR DESCRIPTION
---
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요.
title: "[PR] 리터치 틀린 문제 리스트 조회 기능 구현 "
---

## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #19` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

> 틀린 문제 리스트 조회 기능 구현
> 틀린 문제 다시 풀기 제출 기능은 기존에 구현한 결과제출 API로 재사용 가능
> 다시 제출하여 정답처리가 될 경우 틀린 문제 리스트 조회 시, 리스트에서 제외되도록 구현함

## #️⃣ 테스트 결과

> 틀린 문제 리스트 조회 테스트 성공
> 다시 제출하여 정답처리 된 후, 다시 리스트 조회 시 틀린 문제에서 제외되는 테스트 케이스 성공

## #️⃣ 스크린샷 (선택)

>  
<img width="958" height="867" alt="image" src="https://github.com/user-attachments/assets/57d51996-7079-4a6b-be0e-791dfe4c7b92" />




## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요