### PR TITLE
feat : 사용자 정보 조회 기능 추가

### DIFF
--- a/src/main/java/com/teachtouch/backend/user/controller/UserController.java
+++ b/src/main/java/com/teachtouch/backend/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.teachtouch.backend.user.controller;
 
 import com.teachtouch.backend.auth.dto.TokenRefreshRequestDto;
 import com.teachtouch.backend.auth.dto.TokenRefreshResponseDto;
+import com.teachtouch.backend.user.dto.UserInfoResponseDto;
 import com.teachtouch.backend.user.dto.UserLoginRequestDto;
 import com.teachtouch.backend.user.dto.UserLoginResponseDto;
 import com.teachtouch.backend.user.dto.UserSignupRequestDto;
@@ -53,6 +54,12 @@ public class UserController {
         userService.logout(loginId);
         return ResponseEntity.ok("로그아웃 완료");
     }
+
+    @GetMapping("/me")
+    public ResponseEntity<UserInfoResponseDto> getMyInfo(@RequestHeader("Authorization") String token) {
+        return ResponseEntity.ok(userService.getUserInfo(token));
+    }
+
 
 
 

--- a/src/main/java/com/teachtouch/backend/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/teachtouch/backend/user/dto/UserInfoResponseDto.java
@@ -1,0 +1,31 @@
+package com.teachtouch.backend.user.dto;
+
+
+import com.teachtouch.backend.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class UserInfoResponseDto {
+    private Long id;
+    private String loginId;
+    private String username;
+    private String gender;
+    private LocalDate birthDate;
+    private String profileImgUrl;
+
+    public static UserInfoResponseDto from(User user) {
+        return new UserInfoResponseDto(
+                user.getId(),
+                user.getLoginId(),
+                user.getUsername(),
+                user.getGender(),
+                user.getBirthDate(),
+                user.getProfileImageUrl()
+        );
+    }
+}
+

--- a/src/main/java/com/teachtouch/backend/user/entity/User.java
+++ b/src/main/java/com/teachtouch/backend/user/entity/User.java
@@ -49,4 +49,7 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user")
     private List<SolveHistory> solveHistories = new ArrayList<>(); //테스트 기록
 
+    @Column
+    private String profileImageUrl;
+
     }

--- a/src/main/java/com/teachtouch/backend/user/service/UserService.java
+++ b/src/main/java/com/teachtouch/backend/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.teachtouch.backend.user.service;
 
 import com.teachtouch.backend.auth.dto.TokenRefreshRequestDto;
 import com.teachtouch.backend.auth.dto.TokenRefreshResponseDto;
+import com.teachtouch.backend.user.dto.UserInfoResponseDto;
 import com.teachtouch.backend.user.dto.UserLoginRequestDto;
 import com.teachtouch.backend.user.dto.UserLoginResponseDto;
 import com.teachtouch.backend.user.dto.UserSignupRequestDto;
@@ -22,4 +23,6 @@ public interface UserService {
     boolean checkLoginIdDuplicate(String loginId);
 
     Long getUserIdByLoginId(String loginId);
+
+    UserInfoResponseDto getUserInfo(String token);
 }

--- a/src/main/java/com/teachtouch/backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/teachtouch/backend/user/service/UserServiceImpl.java
@@ -5,6 +5,7 @@ import com.teachtouch.backend.auth.dto.TokenRefreshResponseDto;
 import com.teachtouch.backend.auth.entity.RefreshToken;
 import com.teachtouch.backend.auth.repository.RefreshTokenRepository;
 import com.teachtouch.backend.global.jwt.JwtProvider;
+import com.teachtouch.backend.user.dto.UserInfoResponseDto;
 import com.teachtouch.backend.user.dto.UserLoginRequestDto;
 import com.teachtouch.backend.user.dto.UserLoginResponseDto;
 import com.teachtouch.backend.user.dto.UserSignupRequestDto;
@@ -112,4 +113,13 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
         return user.getId();
     }
+
+    @Override
+    public UserInfoResponseDto getUserInfo(String token) {
+        String loginId = getLoginIdFromToken(token);
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+        return UserInfoResponseDto.from(user);
+    }
+
 }


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #24 ` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

User 에 프로필 이미지 url을 추가하고, 사용자 정보 조회가 되게끔 기능을 추가하였습니다. 
## #️⃣ 테스트 결과

<img width="1172" height="953" alt="image" src="https://github.com/user-attachments/assets/15605875-ab13-4669-8d29-6625227e2ff8" />

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요