### PR TITLE
refactor: 가이드 스텝별 진도 저장 추가

### DIFF
--- a/src/main/java/com/teachtouch/backend/guide/controller/GuideController.java
+++ b/src/main/java/com/teachtouch/backend/guide/controller/GuideController.java
@@ -84,28 +84,51 @@ public class GuideController {
         );
     }
 
-    /* Step 단위 완료 저장 */
-    @PostMapping("/steps/{stepId}/complete")
-    public ResponseEntity<Void> completeStep(@PathVariable Long stepId,
-                                             @AuthenticationPrincipal UserDetails user) {
-        Long userId = ((CustomUserDetails) user).getUser().getId();
-        guideService.markStepAsCompleted(stepId, userId);
+//    /* Step 단위 완료 저장 */
+//    @PostMapping("/steps/{stepId}/complete")
+//    public ResponseEntity<Void> completeStep(@PathVariable Long stepId,
+//                                             @AuthenticationPrincipal UserDetails user) {
+//        Long userId = ((CustomUserDetails) user).getUser().getId();
+//        guideService.markStepAsCompleted(stepId, userId);
+//        return ResponseEntity.ok().build();
+//    }
+
+
+    //    /* Step 단위 완료 조회 */
+//    @GetMapping("/{guideId}/steps/progress")
+//    public ResponseEntity<List<String>> getUserCompletedSteps(
+//            @PathVariable Long guideId,
+//            @AuthenticationPrincipal CustomUserDetails user) {
+//
+//        Long userId = user.getUser().getId();
+//        List<String> completed = guideService.getCompletedStepCodes(userId, guideId);
+//        return ResponseEntity.ok(completed);
+//    }
+
+    /* Step 단위 완료 저장 -> 1-1. 1-2 방식으로 저장할 수 있게 수정*/
+    @PostMapping("/{stepCode}/complete")
+    public ResponseEntity<Void> completeStep(
+            @PathVariable String stepCode,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Long userId = user.getUser().getId();
+        guideService.markStepAsCompleted(stepCode, userId);
         return ResponseEntity.ok().build();
     }
 
-    /* Step 단위 완료 조회 */
+    /* Step 단위 완료 조회 -> 특정 가이드 내 사용자가 완료한 stepCode 목록(1-1,1-2) 반환 */
     @GetMapping("/{guideId}/steps/progress")
-    public ResponseEntity<List<String>> getUserCompletedSteps(
+    public ResponseEntity<List<String>> getCompletedSteps(
             @PathVariable Long guideId,
-            @AuthenticationPrincipal CustomUserDetails user) {
-
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
         Long userId = user.getUser().getId();
-        List<String> completed = guideService.getCompletedStepCodes(userId, guideId);
-        return ResponseEntity.ok(completed);
+        List<String> completedStepCodes = guideService.getCompletedStepCodes(userId, guideId);
+        return ResponseEntity.ok(completedStepCodes);
     }
 
     /* Guide 단위 완료 저장 */
-    @PostMapping("/{guideId}/complete")
+    @PostMapping("/{guideId}/guides/complete")
     public ResponseEntity<Void> completeGuide(
             @PathVariable Long guideId,
             @AuthenticationPrincipal CustomUserDetails user) {

--- a/src/main/java/com/teachtouch/backend/guide/repository/StepProgressRepository.java
+++ b/src/main/java/com/teachtouch/backend/guide/repository/StepProgressRepository.java
@@ -15,5 +15,6 @@ public interface StepProgressRepository extends JpaRepository<StepProgress, Long
     List<StepProgress> findByUser(User user);
 
     List<StepProgress> findByUserAndStep_Guide_IdAndCompletedTrue(User user, Long guideId);
+    List<StepProgress> findByUserIdAndStep_Guide_IdAndCompletedTrue(Long userId, Long guideId);
 
 }

--- a/src/main/java/com/teachtouch/backend/guide/repository/StepRepository.java
+++ b/src/main/java/com/teachtouch/backend/guide/repository/StepRepository.java
@@ -3,5 +3,9 @@ package com.teachtouch.backend.guide.repository;
 import com.teachtouch.backend.guide.entity.Step;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface StepRepository extends JpaRepository<Step,Long> {
+    Optional<Step> findByStepCode(String stepCode);
+
 }

--- a/src/main/java/com/teachtouch/backend/guide/service/GuideService.java
+++ b/src/main/java/com/teachtouch/backend/guide/service/GuideService.java
@@ -12,7 +12,6 @@ public interface GuideService {
     List<Guide> findAll();
     Optional<Guide> findById(Long id);
     List<Guide> searchByKeyword(String keyword);
-    void markStepAsCompleted(Long stepId, Long userId);
     List<String> getCompletedStepCodes(Long userId, Long guideId);
 
     // 추가
@@ -20,4 +19,7 @@ public interface GuideService {
     Map<Long, Boolean> areGuidesCompleted(Long userId, List<Long> guideIds);
     void markGuideAsCompleted(Long guideId, Long userId); // 추후 전용 API용
     void deleteGuide(Long guideId);
+
+    void markStepAsCompleted(String stepCode, Long userId);
+
 }


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #28` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

가이드 별로 학습 완료가 저장되었는데,
step별로도 저장되게끔 수정하였습니다.

또한 step별 학습 완료 저장 엔드포인트가 guide별 학습 완료 저장 엔드포인트와 충돌이 날 수 있어 가이드쪽 엔드포인트를 수정하였습니다.
{guideId}/complete -> {guideId}/guides/complete

## #️⃣ 테스트 결과

<img width="1554" height="848" alt="image" src="https://github.com/user-attachments/assets/b7837b45-5a31-4961-838a-9164af982319" />
<img width="1575" height="969" alt="image" src="https://github.com/user-attachments/assets/2ae60991-a369-4fe8-9fca-004be264712c" />

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요