### PR TITLE
feat: ocr 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 
 	// Google TTS
 	implementation 'com.google.cloud:google-cloud-texttospeech:2.68.0'
+
+	// Google Vision
+	implementation 'com.google.cloud:google-cloud-vision:3.34.0'
 }
 
 

--- a/src/main/java/com/teachtouch/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/teachtouch/backend/global/config/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
                                 "/api/v1.0/retouch/progress/all",
                                 "/api/v1.0/retouch/progress/*",
                                 "/api/v1.0/retouch/submit",
-                                "/api/v1.0/retouch/wrong"
+                                "/api/v1.0/retouch/wrong",
+                                "/api/v1.0/ocr/extract-ui"
 
 
                         ).permitAll()

--- a/src/main/java/com/teachtouch/backend/ocr/controller/OCRController.java
+++ b/src/main/java/com/teachtouch/backend/ocr/controller/OCRController.java
@@ -2,25 +2,27 @@ package com.teachtouch.backend.ocr.controller;
 
 import com.teachtouch.backend.ocr.serivce.VisionService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
 
 @RestController
 @RequestMapping("/api/v1.0/ocr")
+
 public class OCRController {
 
-    @Autowired
-    private VisionService visionService;
+    private final VisionService visionService;
 
-    @GetMapping("/extract-ui")
-    public String extractUi(@RequestParam("imageUrl") String imageUrl) {
-        try {
-            return visionService.extractUiComponentsFromImageUrl(imageUrl);
-        } catch (Exception e) {
-            return "Failed to extract UI components: " + e.getMessage();
-        }
+    public OCRController(VisionService visionService) {
+        this.visionService = visionService;
     }
 
+    @PostMapping("/extract-ui")
+    public String extractText(@RequestParam("file") MultipartFile file) {
+        try {
+            return visionService.extractUiComponentsFromFile(file);
+        } catch (Exception e) {
+            return "Failed to extract text: " + e.getMessage();
+        }
+    }
 }

--- a/src/main/java/com/teachtouch/backend/ocr/controller/OCRController.java
+++ b/src/main/java/com/teachtouch/backend/ocr/controller/OCRController.java
@@ -1,0 +1,26 @@
+package com.teachtouch.backend.ocr.controller;
+
+import com.teachtouch.backend.ocr.serivce.VisionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1.0/ocr")
+public class OCRController {
+
+    @Autowired
+    private VisionService visionService;
+
+    @GetMapping("/extract-ui")
+    public String extractUi(@RequestParam("imageUrl") String imageUrl) {
+        try {
+            return visionService.extractUiComponentsFromImageUrl(imageUrl);
+        } catch (Exception e) {
+            return "Failed to extract UI components: " + e.getMessage();
+        }
+    }
+
+}

--- a/src/main/java/com/teachtouch/backend/ocr/serivce/VisionService.java
+++ b/src/main/java/com/teachtouch/backend/ocr/serivce/VisionService.java
@@ -1,0 +1,116 @@
+package com.teachtouch.backend.ocr.serivce;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.vision.v1.AnnotateImageRequest;
+import com.google.cloud.vision.v1.AnnotateImageResponse;
+import com.google.cloud.vision.v1.BatchAnnotateImagesResponse;
+import com.google.cloud.vision.v1.Feature;
+import com.google.cloud.vision.v1.Image;
+import com.google.cloud.vision.v1.ImageAnnotatorClient;
+import com.google.protobuf.ByteString;
+import org.springframework.stereotype.Service;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.*;
+import java.util.stream.Collectors;
+
+
+@Service
+public class VisionService {
+
+    public String extractUiComponentsFromImageUrl(String imageUrl) throws Exception {
+        ByteString imgBytes = ByteString.readFrom(new URL(imageUrl).openStream());
+        Image img = Image.newBuilder().setContent(imgBytes).build();
+        Feature feat = Feature.newBuilder().setType(Feature.Type.DOCUMENT_TEXT_DETECTION).build();
+        AnnotateImageRequest request = AnnotateImageRequest.newBuilder()
+                .addFeatures(feat).setImage(img).build();
+
+        try (ImageAnnotatorClient client = ImageAnnotatorClient.create()) {
+            AnnotateImageResponse res = client.batchAnnotateImages(List.of(request)).getResponses(0);
+            if (res.hasError()) return "Error: " + res.getError().getMessage();
+
+            List<Map<String, Object>> components = new ArrayList<>();
+
+            for (var page : res.getFullTextAnnotation().getPagesList()) {
+                for (var block : page.getBlocksList()) {
+                    for (var para : block.getParagraphsList()) {
+                        for (var word : para.getWordsList()) {
+                            StringBuilder wordText = new StringBuilder();
+                            for (var symbol : word.getSymbolsList()) {
+                                wordText.append(symbol.getText());
+                            }
+                            String text = wordText.toString();
+
+                            var vertices = word.getBoundingBox().getVerticesList();
+                            int x = (vertices.get(0).getX() + vertices.get(2).getX()) / 2;
+                            int y = (vertices.get(0).getY() + vertices.get(2).getY()) / 2;
+
+                            if (text.length() <= 1 && text.matches("[()0-9]+")) continue;
+
+                            Map<String, Object> item = new LinkedHashMap<>();
+                            item.put("label", text);
+                            item.put("x", x);
+                            item.put("y", y);
+                            components.add(item);
+                        }
+                    }
+                }
+            }
+
+            List<Map<String, Object>> merged = mergeByLine(components);
+
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(merged);
+        }
+    }
+
+    private List<Map<String, Object>> mergeByLine(List<Map<String, Object>> items) {
+        List<Map<String, Object>> merged = new ArrayList<>();
+
+        items.sort(Comparator
+                .comparingInt((Map<String, Object> c) -> ((Number) c.get("y")).intValue())
+                .thenComparingInt(c -> ((Number) c.get("x")).intValue()));
+
+
+        List<Map<String, Object>> currentLine = new ArrayList<>();
+        int yThreshold = 12;
+        int prevY = -9999;
+
+        for (Map<String, Object> comp : items) {
+            int currY = ((Number) comp.get("y")).intValue();
+            if (Math.abs(currY - prevY) <= yThreshold) {
+                currentLine.add(comp);
+            } else {
+                if (!currentLine.isEmpty()) {
+                    merged.add(buildMergedItem(currentLine));
+                    currentLine.clear();
+                }
+                currentLine.add(comp);
+            }
+            prevY = currY;
+        }
+        if (!currentLine.isEmpty()) merged.add(buildMergedItem(currentLine));
+
+        return merged;
+    }
+
+    private Map<String, Object> buildMergedItem(List<Map<String, Object>> line) {
+        line.sort(Comparator.comparingInt(c -> ((Number) c.get("x")).intValue()));
+
+        StringBuilder label = new StringBuilder();
+        int x = ((Number) line.get(0).get("x")).intValue();
+        int y = ((Number) line.get(0).get("y")).intValue();
+
+        for (Map<String, Object> word : line) {
+            label.append(word.get("label")).append(" ");
+        }
+
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("label", label.toString().trim());
+        item.put("x", x);
+        item.put("y", y);
+        return item;
+    }
+
+}
+

--- a/src/main/java/com/teachtouch/backend/ocr/serivce/VisionService.java
+++ b/src/main/java/com/teachtouch/backend/ocr/serivce/VisionService.java
@@ -9,53 +9,64 @@ import com.google.cloud.vision.v1.Image;
 import com.google.cloud.vision.v1.ImageAnnotatorClient;
 import com.google.protobuf.ByteString;
 import org.springframework.stereotype.Service;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.*;
-import java.util.stream.Collectors;
 
+import java.util.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 public class VisionService {
 
-    public String extractUiComponentsFromImageUrl(String imageUrl) throws Exception {
-        ByteString imgBytes = ByteString.readFrom(new URL(imageUrl).openStream());
+    public String extractUiComponentsFromFile(MultipartFile file) throws Exception {
+        ByteString imgBytes = ByteString.readFrom(file.getInputStream());
         Image img = Image.newBuilder().setContent(imgBytes).build();
-        Feature feat = Feature.newBuilder().setType(Feature.Type.DOCUMENT_TEXT_DETECTION).build();
+        return processImage(img);
+    }
+
+    private String processImage(Image img) throws Exception {
+        Feature feat = Feature.newBuilder()
+                .setType(Feature.Type.DOCUMENT_TEXT_DETECTION)
+                .build();
+
         AnnotateImageRequest request = AnnotateImageRequest.newBuilder()
-                .addFeatures(feat).setImage(img).build();
+                .addFeatures(feat)
+                .setImage(img)
+                .build();
 
         try (ImageAnnotatorClient client = ImageAnnotatorClient.create()) {
-            AnnotateImageResponse res = client.batchAnnotateImages(List.of(request)).getResponses(0);
-            if (res.hasError()) return "Error: " + res.getError().getMessage();
+            AnnotateImageResponse res =
+                    client.batchAnnotateImages(Collections.singletonList(request))
+                            .getResponses(0);
+
+            if (res.hasError()) {
+                return "Error: " + res.getError().getMessage();
+            }
 
             List<Map<String, Object>> components = new ArrayList<>();
+            res.getFullTextAnnotation().getPagesList().forEach(page ->
+                    page.getBlocksList().forEach(block ->
+                            block.getParagraphsList().forEach(para ->
+                                    para.getWordsList().forEach(word -> {
+                                        StringBuilder wordText = new StringBuilder();
+                                        word.getSymbolsList().forEach(symbol ->
+                                                wordText.append(symbol.getText())
+                                        );
+                                        String text = wordText.toString();
 
-            for (var page : res.getFullTextAnnotation().getPagesList()) {
-                for (var block : page.getBlocksList()) {
-                    for (var para : block.getParagraphsList()) {
-                        for (var word : para.getWordsList()) {
-                            StringBuilder wordText = new StringBuilder();
-                            for (var symbol : word.getSymbolsList()) {
-                                wordText.append(symbol.getText());
-                            }
-                            String text = wordText.toString();
+                                        var vertices = word.getBoundingBox().getVerticesList();
+                                        int x = (vertices.get(0).getX() + vertices.get(2).getX()) / 2;
+                                        int y = (vertices.get(0).getY() + vertices.get(2).getY()) / 2;
 
-                            var vertices = word.getBoundingBox().getVerticesList();
-                            int x = (vertices.get(0).getX() + vertices.get(2).getX()) / 2;
-                            int y = (vertices.get(0).getY() + vertices.get(2).getY()) / 2;
+                                        if (text.length() <= 1 && text.matches("[()0-9]+")) return;
 
-                            if (text.length() <= 1 && text.matches("[()0-9]+")) continue;
-
-                            Map<String, Object> item = new LinkedHashMap<>();
-                            item.put("label", text);
-                            item.put("x", x);
-                            item.put("y", y);
-                            components.add(item);
-                        }
-                    }
-                }
-            }
+                                        Map<String, Object> item = new LinkedHashMap<>();
+                                        item.put("label", text);
+                                        item.put("x", x);
+                                        item.put("y", y);
+                                        components.add(item);
+                                    })
+                            )
+                    )
+            );
 
             List<Map<String, Object>> merged = mergeByLine(components);
 
@@ -63,6 +74,7 @@ public class VisionService {
             return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(merged);
         }
     }
+
 
     private List<Map<String, Object>> mergeByLine(List<Map<String, Object>> items) {
         List<Map<String, Object>> merged = new ArrayList<>();


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #41 ` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

- Google Vision API 연동하여 업로드된 이미지 파일을 기반으로 DOCUMENT_TEXT_DETECTION를 수행합니다.
- OCR 결과에서 단어단위 텍스트를 추출하고, 해당 텍스트에 대한 좌표를 추출합니다. 이 좌표는 추후 AI를 이용한 안내 문구 작성시 위치를 안내할 때 사용됩니다.
- 같은 속성의 텍스트 단위로 반환되는 것이 아닌 단어 단위로 반환되는 문제가 있어 따로 병합 로직을 추가했습니다. 
    - 같은 y축 라인 단위로 텍스트를 병합하여 , 
    - "결제 + 하기" → "결제하기", "선택한 + 상품" → "선택한 상품" 등 문맥 단위로 합쳐서 반환할 수 있도록 하였습니다.
- OCR 결과는 Json 형식(label,x,y)로 반환됩니다.

- * 같은 구글 서비스 계정 키를 사용하므로 이  기능을 추가했을 때 tts도 동시에 요청이 가는 것을 확인했습니다.

## #️⃣ 테스트 결과

<img width="1679" height="1266" alt="image" src="https://github.com/user-attachments/assets/09d7f3a2-17f5-49b6-a347-0710fb5782a8" />

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요