### PR TITLE
fix: 중복 출석체크시 403오류 대신 CheckInResponseDto로 응답

### DIFF
--- a/src/main/java/com/teachtouch/backend/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/teachtouch/backend/attendance/controller/AttendanceController.java
@@ -1,6 +1,7 @@
 package com.teachtouch.backend.attendance.controller;
 
 import com.teachtouch.backend.attendance.dto.AttendanceResponseDto;
+import com.teachtouch.backend.attendance.dto.CheckInResponseDto;
 import com.teachtouch.backend.attendance.dto.WeeklyAttendanceResponseDto;
 import com.teachtouch.backend.attendance.service.AttendanceService;
 import com.teachtouch.backend.global.security.CustomUserDetails;
@@ -22,9 +23,9 @@ public class AttendanceController {
     private final AttendanceService attendanceService;
 
     @PostMapping("/check-in")
-    public ResponseEntity<Void> checkIn(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        attendanceService.checkIn(userDetails.getUser().getId());
-        return ResponseEntity.ok().build();
+    public ResponseEntity<CheckInResponseDto> checkIn(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        CheckInResponseDto response = attendanceService.checkIn(userDetails.getUser().getId());
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/history")

--- a/src/main/java/com/teachtouch/backend/attendance/dto/CheckInResponseDto.java
+++ b/src/main/java/com/teachtouch/backend/attendance/dto/CheckInResponseDto.java
@@ -1,0 +1,19 @@
+package com.teachtouch.backend.attendance.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CheckInResponseDto {
+    private boolean success;
+    private String message;
+
+    public static CheckInResponseDto success(String message) {
+        return new CheckInResponseDto(true, message);
+    }
+
+    public static CheckInResponseDto alreadyCheckIn(String message) {
+        return new CheckInResponseDto(true, message);
+    }
+}

--- a/src/main/java/com/teachtouch/backend/attendance/service/AttendanceService.java
+++ b/src/main/java/com/teachtouch/backend/attendance/service/AttendanceService.java
@@ -1,12 +1,13 @@
 package com.teachtouch.backend.attendance.service;
 
 import com.teachtouch.backend.attendance.dto.AttendanceResponseDto;
+import com.teachtouch.backend.attendance.dto.CheckInResponseDto;
 import com.teachtouch.backend.attendance.dto.WeeklyAttendanceResponseDto;
 
 import java.util.List;
 
 public interface AttendanceService {
-    void checkIn(Long userId);
+    CheckInResponseDto checkIn(Long userId);
     List<AttendanceResponseDto> getAttendanceHistory(Long userId);
     WeeklyAttendanceResponseDto getWeeklyAttendanceStatus(Long userId);
 }

--- a/src/main/java/com/teachtouch/backend/attendance/service/AttendanceServiceImpl.java
+++ b/src/main/java/com/teachtouch/backend/attendance/service/AttendanceServiceImpl.java
@@ -1,6 +1,7 @@
 package com.teachtouch.backend.attendance.service;
 
 import com.teachtouch.backend.attendance.dto.AttendanceResponseDto;
+import com.teachtouch.backend.attendance.dto.CheckInResponseDto;
 import com.teachtouch.backend.attendance.dto.WeeklyAttendanceResponseDto;
 import com.teachtouch.backend.attendance.entity.Attendance;
 import com.teachtouch.backend.attendance.repository.AttendanceRepository;
@@ -27,13 +28,13 @@ public class AttendanceServiceImpl implements AttendanceService {
     private final UserRepository userRepository;
 
     @Override
-    public void checkIn(Long userId) {
+    public CheckInResponseDto checkIn(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저를 찾을 수 없습니다: " + userId));
 
         LocalDate today = LocalDate.now();
         if(attendanceRepository.existsByUserAndAttendanceDate(user, today)) {
-            throw new IllegalArgumentException("이미 오늘 출석체크 했습니다");
+            return CheckInResponseDto.alreadyCheckIn("이미 오늘 출석체크를 완료했습니다.");
         }
 
         Attendance attendance = Attendance.builder()
@@ -41,6 +42,8 @@ public class AttendanceServiceImpl implements AttendanceService {
                 .attendanceDate(today)
                 .build();
         attendanceRepository.save(attendance);
+
+        return CheckInResponseDto.success("출석체크가 완료되었습니다.");
     }
 
     @Override


### PR DESCRIPTION
---
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요.
title: "[PR] 중복 출석체크시 403오류 대신 CheckInResponseDto로 응답"
---

## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #51 ` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

> 중복 출석체크시 403오류 대신 CheckInResponseDto로 응답

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등


## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.
<img width="959" height="1030" alt="image" src="https://github.com/user-attachments/assets/6ec6f9ce-3de2-467a-9900-9e4bceb5f96f" />


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요